### PR TITLE
Fix deprecation on _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ github:  "tholman"
 analytics_tracking_id: "UA-22825241-1"
 
 # Misc variables
-pygments: true
+highlighter: 'pygments'
 encoding: utf-8
 
 # Number of posts on each page.


### PR DESCRIPTION
There was a deprecation warning when running `jekyll serve`:

```bash
Configuration file: /Users/romulo/Projects/inspiring-online/_config.yml
       Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
            Source: /Users/romulo/Projects/inspiring-online
       Destination: /Users/romulo/Projects/inspiring-online/_site
      Generating...
Performing Sass Conversion.
                    done.
```

This PR fixes that deprecation, when running `jekyll serve` now everything looks fine:

```bash
Configuration file: /Users/romulo/Projects/inspiring-online/_config.yml
            Source: /Users/romulo/Projects/inspiring-online
       Destination: /Users/romulo/Projects/inspiring-online/_site
      Generating...
Performing Sass Conversion.
                    done.
```