### PR TITLE
Changed link in Paper Letter post to go to maker's personal site

### DIFF
--- a/_posts/2016-03-07-paper-letter-typography.md
+++ b/_posts/2016-03-07-paper-letter-typography.md
@@ -14,4 +14,4 @@ _Who doesn't love [pretty letters](http://jxnblk.com/papercraft)?_
 
 These beautifully crafted paper SVG elements will class up any website.
 
-[Papercraft](http://jxnblk.com/papercraft) was [open-sourced](https://github.com/jxnblk/papercraft) by [Brent Jackson](https://github.com/jxnblk)
+[Papercraft](http://jxnblk.com/papercraft) was [open-sourced](https://github.com/jxnblk/papercraft) by [Brent Jackson](http://jxnblk.com)


### PR DESCRIPTION
Right now it links to his GitHub account. I changed it so it leads to his own, personal website.