### PR TITLE
Made blurbs shorter without extra links

### DIFF
--- a/_posts/2015-09-12-emotions-through-css.md
+++ b/_posts/2015-09-12-emotions-through-css.md
@@ -9,6 +9,6 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 ---
 
-_Listen to [Tammie Lister](http://diaryofawebsite.com) talk about bringing out life-like emotions in your website, with CSS._
+_Listen to a talk about bringing out life-like emotions in your website, with CSS._
 
 By [Tammie Lister](http://diaryofawebsite.com/)

--- a/_posts/2015-10-07-music-emojis.md
+++ b/_posts/2015-10-07-music-emojis.md
@@ -12,6 +12,6 @@ imgWidth: 639
 imgHeight: 390
 ---
 
-_[This](http://musicemojis.tumblr.com) little Tumblr blog by [Bruno Leo Ribeiro](http://www.brunoleoribeiro.com/#kauko-home) showcases his creative art style, as he shows each band member in the minimal style of emojis!_
+_A showcase of musicians in the minimal style of emojis!_
 
 By [Bruno Leo Ribeiro](http://www.brunoleoribeiro.com/#kauko-home)

--- a/_posts/2015-10-08-briiian.md
+++ b/_posts/2015-10-08-briiian.md
@@ -12,6 +12,4 @@ imgWidth: 600
 imgHeight: 250
 ---
 
-_[Brian Moore's](http://briiiiian.com) folio website is an awesome showcase of work... what's more, pressing 'i' on the keyboard provides a nice little easter egg. Check it out!_
-
-By Brian (naturally)
+_Brian Moore's folio website is an awesome showcase of work... what's more, pressing 'i' on the keyboard provides a nice little easter egg. Check it out!_

--- a/_posts/2015-10-13-glitch.md
+++ b/_posts/2015-10-13-glitch.md
@@ -12,6 +12,6 @@ imgWidth: 1153
 imgHeight: 644
 ---
 
-_[This Three.js EffectComposer Glitch](http://codepen.io/ryonakae/full/PPKxyw) by Japanese developer [Ryo Nakae](http://brdr.jp) demonstrates some of the cooler ways you can use shaders to add extra effects to your models._
+_A demonstration of some of the cooler ways you can use shaders to add extra effects to your models._
 
 By [Ryo Nakae](http://brdr.jp)

--- a/_posts/2015-10-22-humans-dot-text.md
+++ b/_posts/2015-10-22-humans-dot-text.md
@@ -12,6 +12,6 @@ imgWidth: 980
 imgHeight: 542
 ---
 
-_[Tumblr's humans.txt](http://tumblr.com/humans.txt) file, turns out to be an awesome text adventure. What a great little easter egg._
+_It turns out that this file is an awesome text adventure. What a great little easter egg._
 
 By [Tumblr](http://tumblr.com)

--- a/_posts/2015-10-23-elastic-loading-bars.md
+++ b/_posts/2015-10-23-elastic-loading-bars.md
@@ -12,6 +12,6 @@ imgWidth: 990
 imgHeight: 576
 ---
 
-_[These Elastic Loaders](http://tympanus.net/Development/ElasticProgress) show how beautiful a little SVG animation can be._
+_These loaders show how beautiful a little SVG animation can be._
 
 By [Typmpanus](http://tympanus.net)

--- a/_posts/2015-10-26-swiss-style-color-picker.md
+++ b/_posts/2015-10-26-swiss-style-color-picker.md
@@ -12,6 +12,6 @@ imgWidth: 1418
 imgHeight: 732
 ---
 
-_This [Swiss style color picker](http://swisscolors.net) is a clever little project by [Fabian Burghardt](http://www.fabianburghardt.de) allowing you to pick colors from palettes inspired by swiss style posters._
+_A clever little project that allows you to pick colors from palettes inspired by Swiss style posters._
 
 By [Fabian Burghardt](http://www.fabianburghardt.de)

--- a/_posts/2015-10-27-do-it-chrome-extension.md
+++ b/_posts/2015-10-27-do-it-chrome-extension.md
@@ -9,6 +9,6 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 ---
 
-_Ever feel like you're lacking motivation? If so, the [Do it!](https://chrome.google.com/webstore/detail/do-it/eppncnmppghbndacgkideegigaminkfg?hl=en) Chrome extension is definitely for you._
+_Ever feel like you're lacking motivation? If so, this Chrome extension is definitely for you._
 
 By [Erik M Taheri](http://taheri.io/)

--- a/_posts/2015-10-28-3d-parallax-icons.md
+++ b/_posts/2015-10-28-3d-parallax-icons.md
@@ -12,6 +12,6 @@ imgWidth: 942
 imgHeight: 568
 ---
 
-_With the new Apple TV well on its way, a few nice little designs have been shipping with it. [This JavaScript library](https://github.com/drewwilson/atvImg) made by [Drew Wilson](http://drewwilson.com/) is bringing Apple’s awesome 3D tiles to the web!_
+_With the new Apple TV well on its way, a few nice little designs have been shipping with it. This JS library brings Apple’s awesome 3D tiles to the web!_
 
 By [Drew Wilson](http://drewwilson.com/)

--- a/_posts/2015-10-30-kitty-keys.md
+++ b/_posts/2015-10-30-kitty-keys.md
@@ -12,6 +12,6 @@ imgWidth: 1182
 imgHeight: 574
 ---
 
-_Sick of the normal sound your keyboard makes as you type? Of course you are. [Kitty Keys](http://www.kittykeys.com) is just for you._
+_Sick of the normal sound your keyboard makes as you type? If so, this extension is just for you._
 
 By [Yvonne Cheng](http://mindeveon.com)

--- a/_posts/2015-11-02-pt-code-experiments.md
+++ b/_posts/2015-11-02-pt-code-experiments.md
@@ -12,6 +12,6 @@ imgWidth: 928
 imgHeight: 456
 ---
 
-_Looking for a little color and interaction inspiration? [William Ngan](http://williamngan.com)'s code experiments exploring [point, form and space](http://williamngan.github.io/pt/index.html) are just for you._
+_Looking for a little color and interaction inspiration? These code experiments are just for you._
 
 By [William Ngan](http://williamngan.com)

--- a/_posts/2015-11-05-type-hunting.md
+++ b/_posts/2015-11-05-type-hunting.md
@@ -12,6 +12,6 @@ imgWidth: 1505
 imgHeight: 1073
 ---
 
-_[Type Hunting](http://typehunting.com) is the perfect fix for the typography junkie looking to score._
+_The perfect fix for a typography junkie looking to score._
 
 By [Jonathan Lawrence](http://jonathanlawrence.net)

--- a/_posts/2015-11-08-poke-palettes.md
+++ b/_posts/2015-11-08-poke-palettes.md
@@ -12,6 +12,6 @@ imgWidth: 1060
 imgHeight: 546
 ---
 
-_[Poke Palettes](http://pokepalettes.com) is a neat little place to find a colorful palette for your next project, or just appreciate the colors and artwork of the 90's classic._
+_A neat little place to find a colorful palette for your next project, or just appreciate the colors and artwork of the 90's classic._
 
 By [Gus Glover](http://gus.today)

--- a/_posts/2015-11-09-cats-cats-cats-cats.md
+++ b/_posts/2015-11-09-cats-cats-cats-cats.md
@@ -12,6 +12,6 @@ imgWidth: 1074
 imgHeight: 622
 ---
 
-_Ever wondered what it's like to be a cat? Now you can [live it](http://catscatscatscatscats.com)._
+_Ever wondered what it's like to be a cat? Now you can live it!_
 
 By [Matthew Morrison](https://twitter.com/stuffmattdoesnt)

--- a/_posts/2015-11-10-hiphop-quoted.md
+++ b/_posts/2015-11-10-hiphop-quoted.md
@@ -12,6 +12,6 @@ imgWidth: 946
 imgHeight: 606
 ---
 
-_Love typography? Love Hip Hop? [Hip Hop Quoted](http://hiphopquoted.com) is for you._
+_Love typography? Love Hip Hop? This is perfect for you._
 
 By [Ollie Kavanagh](http://olliekav.com)

--- a/_posts/2015-11-11-why-skeuomorphism-is-like-a-classic-car.md
+++ b/_posts/2015-11-11-why-skeuomorphism-is-like-a-classic-car.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Neven Mrgan on Why Skeuomorphism Is Like a Classic Car
+title: Why Skeuomorphism Is Like a Classic Car
 type: Talk
 vimeo-id: 116295698
 link: https://vimeo.com/116295698
@@ -9,6 +9,6 @@ authorUrl: https://vaidaslamanauskas.com
 authorGithub: vaidaslamanauskas
 ---
 
-_Enjoy [Neven Mrgan's](http://mrgan.tumblr.com/) lovely comparison between skeuomorphic and flat UI using classic cars._
+_Enjoy a lovely comparison between skeuomorphic and flat UI using classic cars._
 
-By [Story & Pixel](https://vimeo.com/storyandpixel)
+By [Neven Mrgan](http://mrgan.tumblr.com)

--- a/_posts/2015-11-20-keep-portland-weird.md
+++ b/_posts/2015-11-20-keep-portland-weird.md
@@ -12,6 +12,6 @@ imgWidth: 1008
 imgHeight: 642
 ---
 
-_[Keep Portland Weird](http://keepearthquakesweird.com) is the kind of project that keeps the strange alive, on the internet._
+_The kind of project that keeps the strange alive, on the internet._
 
 By Digital Agency [Oblio](http://oblio.io)

--- a/_posts/2015-12-14-sweaterify-it.md
+++ b/_posts/2015-12-14-sweaterify-it.md
@@ -12,6 +12,6 @@ imgWidth: 1440
 imgHeight: 800
 ---
 
-_Ever dreamed of putting your face on a sweater... Of course you have. Now [Sweaterify it](http://kosamari.github.io/sweaterify) is here!_
+_Ever dreamed of putting your face on a sweater..._
 
 By [Mariko Kosaka](http://www.kosamari.com)

--- a/_posts/2016-01-08-ny-library-public-domain.md
+++ b/_posts/2016-01-08-ny-library-public-domain.md
@@ -12,6 +12,6 @@ imgWidth: 1462
 imgHeight: 738
 ---
 
-_Looking for a little inspiration or just for random resources_
+_Looking for a little inspiration or just for random resources?_
 
 By [The NY public library](http://digitalcollections.nypl.org)

--- a/_posts/2016-01-30-museum-of-selfies.md
+++ b/_posts/2016-01-30-museum-of-selfies.md
@@ -12,6 +12,6 @@ imgWidth: 500
 imgHeight: 500
 ---
 
-_The [Museum of Selfies](http://museumofselfies.tumblr.com) is a gallery of old paintings and ancient statues taking selfies._
+_A gallery of old paintings and ancient statues taking selfies._
 
 By Olivia Muus

--- a/_posts/2016-02-10-mojs.md
+++ b/_posts/2016-02-10-mojs.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: mo • js – Motion Graphics For The Web
+title: mo • js
 type: Coding
 image: mojs.png
 link: http://mojs.io
@@ -12,6 +12,6 @@ imgWidth: 1440
 imgHeight: 900
 ---
 
-_[mo • js](http://mojs.io) is a JavaScript animation toolkit for the web._
+_A JavaScript animation toolkit for the web._
 
 By [Oleg Solomka aka legomushroom](https://twitter.com/legomushroom)

--- a/_posts/2016-02-11-drake-disco.md
+++ b/_posts/2016-02-11-drake-disco.md
@@ -12,6 +12,6 @@ imgWidth: 1440
 imgHeight: 900
 ---
 
-_[Drake Disco](http://drakedis.co) – Get Down With Drake!_
+_Get Down With Drake!_
 
 By [Kim Walker](http://walker.kim)

--- a/_posts/2016-02-12-passweird.md
+++ b/_posts/2016-02-12-passweird.md
@@ -12,6 +12,6 @@ imgWidth: 1440
 imgHeight: 900
 ---
 
-_[Passweird](https://passweird.com) is a password generator..._
+_It's a password generator..._
 
 By [Cody Peterson](http://humanshapes.co) & [Matt Carlson](http://plaidmtn.com)

--- a/_posts/2016-02-16-australiacss.md
+++ b/_posts/2016-02-16-australiacss.md
@@ -12,6 +12,6 @@ imgWidth: 720
 imgHeight: 540
 ---
 
-_[australia.css](https://bullg.it/australia.css) is a neat little CSS file making our beloved [Tim Holman](http://tholman) feel right at home._
+_A neat little CSS file making our beloved [Tim Holman](http://tholman.com) feel right at home._
 
 By [Haroen Viaene](https://haroen.me)

--- a/_posts/2016-02-20-trumpdonald.md
+++ b/_posts/2016-02-20-trumpdonald.md
@@ -12,6 +12,6 @@ imgWidth: 720
 imgHeight: 450
 ---
 
-_There's so many Donald Trump stuff to be discovered in the interwebs, but [Trump Donald](http://trumpdonald.org) is our favorite._
+_There's so many Donald Trump stuff to be discovered in the interwebs, but this is our favorite._
 
 By [Animal](http://animal.cc)

--- a/_posts/2016-02-23-sebastian-ly-serena.md
+++ b/_posts/2016-02-23-sebastian-ly-serena.md
@@ -12,6 +12,6 @@ imgWidth: 720
 imgHeight: 450
 ---
 
-_Yeah... [here](http://sebastianlyserena.dk) are some nice... web dominoes?_
+_Yeah... here are some nice... web dominoes?_
 
 By [Sebastian Ly Serena](http://sebastianlyserena.dk)

--- a/_posts/2016-03-07-paper-letter-typography.md
+++ b/_posts/2016-03-07-paper-letter-typography.md
@@ -13,6 +13,6 @@ imgWidth: 1445
 imgHeight: 775
 ---
 
-_Who doesn't love [pretty letters](http://jxnblk.com/papercraft)?_
+_Who doesn't love pretty letters?_
 
 By [Brent Jackson](http://jxnblk.com)

--- a/_posts/2016-03-08-fried-chicken-simulator.md
+++ b/_posts/2016-03-08-fried-chicken-simulator.md
@@ -13,6 +13,6 @@ imgWidth: 684
 imgHeight: 442
 ---
 
-_Here we go again. Truly a gem in our Wide Weird Web. Yes, [Fried Chicken Simulator](http://friedchickensimulator.surge.sh)._
+_Here we go again. Truly a gem in our Wide Weird Web._
 
 By [Austin Mayer](http://mayormayer.com)

--- a/_posts/2016-03-12-staggering-beauty.md
+++ b/_posts/2016-03-12-staggering-beauty.md
@@ -13,6 +13,6 @@ imgWidth: 720
 imgHeight: 450
 ---
 
-_[Staggering Beauty](http://staggeringbeauty.com) is old, but gold._
+_It's old, but it's gold._
 
 By [George Michael Bower](http://aaf.nyc)

--- a/_posts/2016-03-14-fun-css.md
+++ b/_posts/2016-03-14-fun-css.md
@@ -10,6 +10,6 @@ authorUrl: https://vaidaslamanauskas.com
 authorGithub: vaidaslamanauskas
 ---
 
-_If you are in the world of web development, then [this talk](https://www.youtube.com/watch?v=5HP6k43T0yM) is a must watch!_
+_If you are in the world of web development, then this is a must watch!_
 
 By [Tim Holman](http://tholman.com)

--- a/_posts/2016-03-20-paper-peninsula.md
+++ b/_posts/2016-03-20-paper-peninsula.md
@@ -9,6 +9,6 @@ authorUrl: https://vaidaslamanauskas.com
 authorGithub: vaidaslamanauskas
 ---
 
-_UK based agency [Uniform](http://uniform.net) has created an interactive experience for the [Greenwich Peninsula regeneration project](http://greenwichpeninsula.co.uk)._
+_An interactive experience for the [Greenwich Peninsula regeneration project](http://greenwichpeninsula.co.uk)._
 
 By [Uniform](http://uniform.net)

--- a/_posts/2016-04-26-eschersketch.md
+++ b/_posts/2016-04-26-eschersketch.md
@@ -12,6 +12,6 @@ imgWidth: 902
 imgHeight: 506
 ---
 
-_Enjoy a little walk along the fine line between generateive and interactive art._
+_Enjoy a little walk along the fine line between generative and interactive art._
 
 By [Anselm Levskaya](http://www.anselmlevskaya.com/)


### PR DESCRIPTION
A lot of the older blurbs had a link to the site in their blurb. This was redundant since the title already links to the site.

I realize now that I've done this that it probably doesn't matter that much. But I thought I'd still submit this as a pull request so it can be discussed.

Also, after looking at all of the posts one by one, I made [this issue](https://github.com/tholman/inspiring-online/issues/228).