### PR TITLE
Fixes for broken links & dead link detection script

### DIFF
--- a/_posts/2016-01-08-ny-library-public-domain.md
+++ b/_posts/2016-01-08-ny-library-public-domain.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1462
 imgHeight: 738
+siteDown: true
 ---
 
 _Looking for a little inspiration or just for random resources?_

--- a/_posts/2016-06-24-angry-shakespeare.md
+++ b/_posts/2016-06-24-angry-shakespeare.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 950
 imgHeight: 492
+siteDown: true
 ---
 
 _Spice up your Slack room with some Elizabethan smack talk!_

--- a/_posts/2016-08-30-space-advisor.md
+++ b/_posts/2016-08-30-space-advisor.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1388
 imgHeight: 488
+siteDown: true
 ---
 
 _Buckle up for this beautiful space experience._

--- a/_posts/2016-09-06-txtwav.md
+++ b/_posts/2016-09-06-txtwav.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1146
 imgHeight: 228
+siteDown: true
 ---
 
 _Animated text, what could possibly go wrong!_

--- a/_posts/2016-10-05-my-lacroix.md
+++ b/_posts/2016-10-05-my-lacroix.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 720
 imgHeight: 426
+siteDown: true
 ---
 
 _Get weird with your own flavor._

--- a/_posts/2016-11-09-voice-waves.md
+++ b/_posts/2016-11-09-voice-waves.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 736
 imgHeight: 334
+siteDown: true
 ---
 
 _Audio reactive art._

--- a/_posts/2016-11-21-emojwe.md
+++ b/_posts/2016-11-21-emojwe.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 438
 imgHeight: 422
+siteDown: true
 ---
 
 _Make emojis that include everyone._

--- a/_posts/2016-11-22-generative-plants.md
+++ b/_posts/2016-11-22-generative-plants.md
@@ -3,7 +3,7 @@ layout: post
 title: Generative Plants
 type: Beautiful
 image: generative-plants.png
-link: http://www.galaxykate.com/Apps/Prototypes/LTrees/
+link: http://www.galaxykate.com/apps/Prototypes/LTrees/
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
@@ -14,4 +14,4 @@ imgHeight: 382
 
 _Beautiful generative creations, waving in the wind._
 
-[Generative Plants](http://www.galaxykate.com/Apps/Prototypes/LTrees/) - by [Kate Compton](http://www.galaxykate.com/)
+[Generative Plants](http://www.galaxykate.com/apps/Prototypes/LTrees/) - by [Kate Compton](http://www.galaxykate.com/)

--- a/_posts/2016-12-16-giphy-happy-holidays.md
+++ b/_posts/2016-12-16-giphy-happy-holidays.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 796
 imgHeight: 144
+siteDown: true
 ---
 
 _Everybody deserves a good holiday dance party._

--- a/_posts/2017-03-28-codeslide.md
+++ b/_posts/2017-03-28-codeslide.md
@@ -4,7 +4,7 @@ title: CodeSlide
 date: 2017-03-28 14:51:25
 type: Coding
 image: codeslide.png
-link: http://thejameskyle.com/spectacle-code-slide/
+link: https://jamiebuilds.github.io/spectacle-code-slide/
 authorName: Tim Scalzo
 authorUrl:
 authorGithub: TJScalzo
@@ -16,4 +16,4 @@ _A presentation of code that lets you present code._
 
 
 
-[CodeSlide](http://thejameskyle.com/spectacle-code-slide/) - by [James Kyle](http://thejameskyle.com/)
+[CodeSlide](https://jamiebuilds.github.io/spectacle-code-slide/) - by [James Kyle](http://thejameskyle.com/)

--- a/_posts/2017-08-28-gradient-world.md
+++ b/_posts/2017-08-28-gradient-world.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 424
 imgHeight: 320
+siteDown: true
 ---
 
 _Gradients created from real world images._

--- a/_posts/2017-10-05-mr.-squiggles.md
+++ b/_posts/2017-10-05-mr.-squiggles.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 416
 imgHeight: 380
+siteDown: true
 ---
 
 _A nice clean canvas animation tool._

--- a/_posts/2017-11-20-general-relativity.md
+++ b/_posts/2017-11-20-general-relativity.md
@@ -10,6 +10,7 @@ authorUrl:
 authorGithub: TJScalzo
 imgWidth: 800
 imgHeight: 1000
+siteDown: true
 ---
 
 _A super-quick, super-painless guide to the theory that conquered the universe._

--- a/_posts/2017-12-12-okay-good.md
+++ b/_posts/2017-12-12-okay-good.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 776
 imgHeight: 678
+siteDown: true
 ---
 
 _A sad, but cool browser garden._

--- a/_posts/2018-08-02-p5aholic-web-experiments.md
+++ b/_posts/2018-08-02-p5aholic-web-experiments.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 1006
 imgHeight: 604
+siteDown: true
 ---
 
 _Incredible web experiments with canvas and P5.js_

--- a/downTester.py
+++ b/downTester.py
@@ -1,0 +1,47 @@
+import os
+import urllib
+import sys
+
+posts = {}
+
+for f in os.listdir('_posts'):
+    with open("_posts/{}".format(f)) as m:
+
+        down = False
+
+        # Seperate the file into lines
+        lines = m.read().split("\n")
+
+        for line in lines:
+
+            if line[0:9] == "siteDown:":
+                # If the site's already down
+                if line[10:] == "true":
+                    # Mark the site as down so we can't add it to the list
+                    down = True
+                    # Attempt to remove it in case siteDown was after link
+                    posts.pop(f)
+
+            # If the line contains the link for the post
+            if line[0:5] == "link:" and not down:
+                # Add to list of urls
+                posts[f] = line[6:]
+
+
+for site in posts.keys():
+
+    req = urllib.request.Request(
+        posts[site],
+        data=None,
+        headers={
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'
+        }
+    )
+
+    try:
+        code = urllib.request.urlopen(req).getcode()
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        print(posts[site], e, site)
+
+    if code != 200:
+        print(posts[site], code, site)


### PR DESCRIPTION
I've made a python script to detect possible down links and gone through all the ones it's picked up and fixed them all. I marked all the links that are down with `siteDown: true` and fixed two links that seem to have moved Generative Plants (2016-11-22-generative-plants.md) and CodeSlide ( 2017-03-28-codeslide.md). I'm relatively new to PRs so if you can, I won't mind if you don't want the script and just take 1869f3971bc52a6f13282a6664e61bcdb4360109

This'll close #314 