### PR TITLE
Fix for a load of moved/dead links

### DIFF
--- a/_posts/2016-01-08-ny-library-public-domain.md
+++ b/_posts/2016-01-08-ny-library-public-domain.md
@@ -3,7 +3,7 @@ layout: post
 title: NY Library Public Domain Collections
 type: Resource
 image: ny-public-library-public-domain.png
-link: http://digitalcollections.nypl.org/collections/collection-of-the-dresses-of-different-nations-antient-sic-and-modern
+link: https://digitalcollections.nypl.org/collections/a-collection-of-the-dresses-of-different-nations-antient-sic-and-modern
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman

--- a/_posts/2016-06-02-your-name-in-gum.md
+++ b/_posts/2016-06-02-your-name-in-gum.md
@@ -10,6 +10,7 @@ authorGithub: TJScalzo
 remoteImage: true
 imgWidth: 750
 imgHeight: 518
+siteDown: true
 ---
 
 _Studies have shown that gum can help concentration, why not use it to make words?_

--- a/_posts/2016-06-24-angry-shakespeare.md
+++ b/_posts/2016-06-24-angry-shakespeare.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 950
 imgHeight: 492
+siteDown: true
 ---
 
 _Spice up your Slack room with some Elizabethan smack talk!_

--- a/_posts/2016-08-30-space-advisor.md
+++ b/_posts/2016-08-30-space-advisor.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1388
 imgHeight: 488
+siteDown: true
 ---
 
 _Buckle up for this beautiful space experience._

--- a/_posts/2016-09-01-new-msft-emojis.md
+++ b/_posts/2016-09-01-new-msft-emojis.md
@@ -3,7 +3,7 @@ layout: post
 title: New MSFT Emojis
 type: Inspirational
 image: new-msft-emojis.png
-link: http://www.alwayswithhonor.com/Microsoft-Emojis
+link: https://www.alwayswithhonor.com/MicrosoftWindows-10-Emojis
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
@@ -14,4 +14,4 @@ imgHeight: 644
 
 _Microsoft are putting out a fresh bunch of emoji, check them out._
 
-[New MSFT Emojis](http://www.alwayswithhonor.com/Microsoft-Emojis) - by [Always With Honor](http://www.alwayswithhonor.com/)
+[New MSFT Emojis](https://www.alwayswithhonor.com/MicrosoftWindows-10-Emojis) - by [Always With Honor](http://www.alwayswithhonor.com/)

--- a/_posts/2016-09-06-txtwav.md
+++ b/_posts/2016-09-06-txtwav.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1146
 imgHeight: 228
+siteDown: true
 ---
 
 _Animated text, what could possibly go wrong!_

--- a/_posts/2016-10-05-my-lacroix.md
+++ b/_posts/2016-10-05-my-lacroix.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 720
 imgHeight: 426
+siteDown: true
 ---
 
 _Get weird with your own flavor._

--- a/_posts/2016-11-09-voice-waves.md
+++ b/_posts/2016-11-09-voice-waves.md
@@ -3,15 +3,16 @@ layout: post
 title: Voice Waves
 type: Beautiful
 image: voice-waves.png
-link: https://bruno-simon.com/lab/voice-waves/
+link: https://bruno-simon.com/lab/experiments/voice-waves/
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
 remoteImage: true
 imgWidth: 736
 imgHeight: 334
+siteDown: true
 ---
 
 _Audio reactive art._
 
-[Voice Waves](Audio reactive art.) - by [Bruno Simon](https://bruno-simon.com/)
+[Voice Waves](https://bruno-simon.com/lab/experiments/voice-waves/) - by [Bruno Simon](https://bruno-simon.com/)

--- a/_posts/2016-11-14-emanation.md
+++ b/_posts/2016-11-14-emanation.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 558
 imgHeight: 332
+siteDown: true
 ---
 
 _Looking for something to weirdly consume more time than is needed, look no further._

--- a/_posts/2016-11-16-pretty-good-news.md
+++ b/_posts/2016-11-16-pretty-good-news.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 1194
 imgHeight: 610
+siteDown: true
 ---
 
 _Some nice news, every time you open a new tab._

--- a/_posts/2016-11-20-longskin.md
+++ b/_posts/2016-11-20-longskin.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 546
 imgHeight: 356
+siteDown: true
 ---
 
 _Another great Codevember sketch._

--- a/_posts/2016-11-21-emojwe.md
+++ b/_posts/2016-11-21-emojwe.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: emojwe
+title: wemoji
 type: Inspiration
 image: emojwe.png
-link: http://emoj-we.com/
+link: https://getwemoji.com/
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
@@ -14,4 +14,4 @@ imgHeight: 422
 
 _Make emojis that include everyone._
 
-[emojwe](http://emoj-we.com/) - by [Brendan Sudol](http://brendansudol.com/)
+[emojwe](https://getwemoji.com/) - by [Brendan Sudol](http://brendansudol.com/)

--- a/_posts/2016-11-22-generative-plants.md
+++ b/_posts/2016-11-22-generative-plants.md
@@ -3,7 +3,7 @@ layout: post
 title: Generative Plants
 type: Beautiful
 image: generative-plants.png
-link: http://www.galaxykate.com/Apps/Prototypes/LTrees/
+link: http://www.galaxykate.com/apps/Prototypes/LTrees/
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
@@ -14,4 +14,4 @@ imgHeight: 382
 
 _Beautiful generative creations, waving in the wind._
 
-[Generative Plants](http://www.galaxykate.com/Apps/Prototypes/LTrees/) - by [Kate Compton](http://www.galaxykate.com/)
+[Generative Plants](http://www.galaxykate.com/apps/Prototypes/LTrees/) - by [Kate Compton](http://www.galaxykate.com/)

--- a/_posts/2016-11-28-datalegreya.md
+++ b/_posts/2016-11-28-datalegreya.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 806
 imgHeight: 298
+siteDown: true
 ---
 
 _Beautiful typeface, with interwoven data._

--- a/_posts/2016-12-16-giphy-happy-holidays.md
+++ b/_posts/2016-12-16-giphy-happy-holidays.md
@@ -10,6 +10,7 @@ authorGithub: tholman
 remoteImage: true
 imgWidth: 796
 imgHeight: 144
+siteDown: true
 ---
 
 _Everybody deserves a good holiday dance party._

--- a/_posts/2017-01-11-yeah-boiiiii.md
+++ b/_posts/2017-01-11-yeah-boiiiii.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 502
 imgHeight: 186
+siteDown: true
 ---
 
 _Yeah boiiiiiiiiiiiiiiiiiii._

--- a/_posts/2017-01-20-2016-management.md
+++ b/_posts/2017-01-20-2016-management.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 370
 imgHeight: 260
+siteDown: true
 ---
 
 _A song for 2016._

--- a/_posts/2017-02-21-mono.md
+++ b/_posts/2017-02-21-mono.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 616
 imgHeight: 356
+siteDown: true
 ---
 
 _A celebration of the lunar new year._

--- a/_posts/2017-03-28-codeslide.md
+++ b/_posts/2017-03-28-codeslide.md
@@ -4,7 +4,7 @@ title: CodeSlide
 date: 2017-03-28 14:51:25
 type: Coding
 image: codeslide.png
-link: http://thejameskyle.com/spectacle-code-slide/
+link: https://jamiebuilds.github.io/spectacle-code-slide/
 authorName: Tim Scalzo
 authorUrl:
 authorGithub: TJScalzo
@@ -16,4 +16,4 @@ _A presentation of code that lets you present code._
 
 
 
-[CodeSlide](http://thejameskyle.com/spectacle-code-slide/) - by [James Kyle](http://thejameskyle.com/)
+[CodeSlide](https://jamiebuilds.github.io/spectacle-code-slide/) - by [James Kyle](http://thejameskyle.com/)

--- a/_posts/2017-04-25-grass.md
+++ b/_posts/2017-04-25-grass.md
@@ -9,6 +9,7 @@ authorUrl: http://tholman.com
 authorGithub: tholman
 imgWidth: 560
 imgHeight: 304
+siteDown: true
 ---
 
 _Some beautiful WebGL Grass._

--- a/_posts/2017-05-01-melter.md
+++ b/_posts/2017-05-01-melter.md
@@ -3,7 +3,7 @@ layout: post
 title: Melter
 type: WideWeirdWeb
 image: melter.png
-link: http://melter.club/
+link: https://pixlpa.com/melter/
 authorName: Tim Holman
 authorUrl: http://tholman.com
 authorGithub: tholman
@@ -13,4 +13,4 @@ imgHeight: 360
 
 _A super melty, lighting feedback in-browser visual experiment created by Andrew Benson using HTML5/WebGL graphics._
 
-[Melter](http://melter.club/) - by [Andrew Benson](https://pixlpa.com/)
+[Melter](https://pixlpa.com/melter/) - by [Andrew Benson](https://pixlpa.com/)

--- a/_posts/2017-10-26-yes-no-maybe.md
+++ b/_posts/2017-10-26-yes-no-maybe.md
@@ -10,6 +10,7 @@ authorUrl:
 authorGithub: TJScalzo
 imgWidth: 700
 imgHeight: 325
+siteDown: true
 ---
 
 _Your very own online magic 8 ball!_

--- a/_posts/2017-11-20-general-relativity.md
+++ b/_posts/2017-11-20-general-relativity.md
@@ -4,7 +4,7 @@ title: General Relativity
 date: 2017-11-20 09:39:50
 type: Resource
 image: general-relativity.png
-link: http://spark.sciencemag.org/generalrelativity/
+link: https://vis.sciencemag.org/generalrelativity/
 authorName: Tim Scalzo
 authorUrl:
 authorGithub: TJScalzo
@@ -16,4 +16,4 @@ _A super-quick, super-painless guide to the theory that conquered the universe._
 
 
 
-[General Relativity](http://spark.sciencemag.org/generalrelativity/) - by [Science Magazine](http://www.sciencemag.org)
+[General Relativity](https://vis.sciencemag.org/generalrelativity/) - by [Science Magazine](http://www.sciencemag.org)

--- a/_posts/2018-04-19-vipercard.md
+++ b/_posts/2018-04-19-vipercard.md
@@ -10,6 +10,7 @@ authorGithub: Synj24
 authorUrl: http://matthewdarylgregory.com/
 imgWidth: 339
 imgHeight: 230
+siteDown: true
 ---
 
 _Create stuff like its 1987!_

--- a/_posts/2018-10-25-really-from.md
+++ b/_posts/2018-10-25-really-from.md
@@ -10,6 +10,7 @@ authorUrl:
 authorGithub: TJScalzo
 imgWidth: 576
 imgHeight: 660
+siteDown: true
 ---
 
 _A showcase of generative art pieces paired with stories of personal history and origin._


### PR DESCRIPTION
This is to replace #315, without the script built in. This'll close #314. The script's at https://gist.github.com/ChildishGiant/6d6c4f38a8bf0925b035a8b87651bfa4 if you want to use it.

There's 2 pages I'm not sure about so I've left them out. They are

- [Fornasetti](http://www.fornasetti.com/) Since it looks different to the image
- [P5aholic web experiments](http://p5aholic.me/series-of-web-design-experiments/day1/) This page is down but the [root site](https://p5aholic.me/) seems to serve a similar purpose.

