### PR TITLE
Fix Links to Category Pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-  
+
   <head>
     <title>{{ $.Site.Title }}</title>
 
@@ -23,7 +23,7 @@
 
   <body>
     {{ partial "header.html" . }}
-    
+
       <div class="wrapper">
 
 
@@ -38,7 +38,7 @@
         <article>
           <div class="inner-wrapper">
             <a href="{{ .RelPermalink }}" class="title"><h1>{{ .Title }}</h1></a>
-            <div class="category"><a href="{{ .Params.Category }}">{{ .Params.Category }}</a></div>
+            <div class="category"><a href="{{ anchorize .Params.Category | absURL }}">{{ .Params.Category }}</a></div>
             {{ if .Truncated }}
               {{ .Summary }}
             {{ else }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
       <article>
         <div class="inner-wrapper">
           <h1>{{ .Title }}</h1>
-           <div class="category"><a href="{{ .Params.Category }}">{{ .Params.Category }}</a></div>
+           <div class="category"><a href="{{ anchorize .Params.Category | absURL }}">{{ .Params.Category }}</a></div>
           {{ .Content }}
         </div>
         <canvas class="canvas-effect" width="50vw" height="50vw" data-category="{{ .Params.Category }}"></canvas>


### PR DESCRIPTION
Currently, the links to categories with spaces don't work. They give a 404 error. This is because the browser is replacing the spaces with `%20` instead of `-` as Hugo expects. 

Also, all of these links are currently relative. This may work on the home page, but anywhere else (pages 2-64 or on a post's page) it does not work. That's because Hugo just appends the category name to the end of the current URL when relative URLs are used.