### PR TITLE
Fix issue: Zigzag overlaps with triangle on older posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,7 +26,9 @@
            <div class="category"><a href="{{ anchorize .Params.Category | absURL }}">{{ .Params.Category }}</a></div>
           {{ .Content }}
         </div>
-        <canvas class="canvas-effect" width="50vw" height="50vw" data-category="{{ .Params.Category }}"></canvas>
+        {{ if .Truncated }}
+          <canvas class="canvas-effect" width="50vw" height="50vw" data-category="{{ .Params.Category }}"></canvas>
+        {{ end }}
         <div class="zigzag slide-up"></div>
         <div class="other-links">
           - See an error? More to add? <a href="https://github.com/tholman/inspiring-online/blob/master/content/{{.File.Path}}" target="_blank">Edit & submit a PR.</a><br>


### PR DESCRIPTION
On pages for older posts that are much shorter, the zigzag divider overlaps with the triangle. See:
![Screen Shot 2020-01-21 at 12 40 21 AM](https://user-images.githubusercontent.com/15825214/72778450-0f654280-3be7-11ea-982a-e096c1df37c1.png)

I've fixed this by copying the if statement that's used in the list layout and using it in the single layout.