### PR TITLE
General fixes for Always Judge a Book by its Cover & 8 Bit Code

### DIFF
--- a/content/posts/2020-02-15-eight-bit-code.md
+++ b/content/posts/2020-02-15-eight-bit-code.md
@@ -20,7 +20,7 @@ Here, we have [Sierpiński's Triangle](https://en.wikipedia.org/wiki/Sierpi%C5%8
 
 {{< twitter 1226924794077159425 >}}
 
-An instance of a beautiful and beloved [staple](https://10print.org/) in the world of generative coding: `10 PRINT CHR$(205.5+RND(1)); : GOTO 10` The randomization of two characters shows so much complexity and beauty!
+This is a great instance of a beautiful and beloved [staple](https://10print.org/) in the world of generative code: `10 PRINT CHR$(205.5+RND(1)); : GOTO 10` The randomization of two characters shows so much complexity and beauty!
 
 {{< twitter 1228093563143180288 >}}
 

--- a/content/posts/2020-02-18-always-judge-a-book.md
+++ b/content/posts/2020-02-18-always-judge-a-book.md
@@ -1,36 +1,36 @@
 ---
 date: "2020-02-18T09:00:00Z"
-title: "Always judge a book by its cover bits'n'pieces."
+title: "Always judge a book by its cover, bits'n'pieces."
 category: code
 more: "And the third tidbit?"
 tags: ["bits'n'pieces"]
 ---
 
-Last week I completed a small weekend project called [Always Judge a Book by its Cover](http://alwaysjudgeabookbyitscover.com/), and rather writing about it, I thought it would be fun to do a breakdown of some of the neater pieces of tech that have gone into it as small breakout examples.
+Last week I completed a small weekend project called [Always Judge a Book by its Cover](http://alwaysjudgeabookbyitscover.com/). Rather write about it, I thought it would be fun to go over some of the neater pieces of tech that have gone into it and break them down into small examples.
 
-The first one, and perhaps most obvious, is the goop effect that sits on the header, and in between each of the books (alternating from white to a light grey). This is done with the JS `canvas` element (although using CSS Houdini would be a good option in the future as well).
+The first, and perhaps the most obvious, is the goop effect that sits on the header and in between each of the books (alternating from white to a light grey). This is created using JS and a `canvas` element. (Although CSS Houdini could be a good option in the future.)
 
 {{< codepen poJvZYL >}}
 
-You can have a look at the code above... ultimately its a fairly simple effect that definitely looks a little more complex than its code.
+You can have a look at the code above... Ultimately, it's a fairly simple effect that definitely looks a little more complex than its actual code.
 
-The second little flair, which was a fun one to make, is the 3d CSS book. 
+The second little flair, which was a fun one to make, is the 3D CSS book. 
 
 {{< codepen gOpMBjL >}}
 
-The book gets its 3d effect by using CSS transforms, as well as the `transform-style: preserve-3d;` property, to give it that semi-realistic feel. The pages are just divs with box shadows and rounded corners. And then to top it all off, the image on the front and back. 
+The book gets its 3D effect from the CSS transform property. I used the `transform-style: preserve-3d;` property to really give it that semi-realistic feel. The pages are just divs with box shadows and rounded corners. And then to top it all off, an image of the cover is used on the front and back.
 
-The inline `padding-top` is there to stop the image from jumping as it loads. There's [lots of movement](https://css-tricks.com/what-if-we-got-aspect-ratio-sized-images-by-doing-almost-nothing/) in patching up this annoying part of loading on the web, but I chose to stick with this old faithful method.
+The inline `padding-top` stops the image from jumping as it loads. There are [lots of thoughts](https://css-tricks.com/what-if-we-got-aspect-ratio-sized-images-by-doing-almost-nothing/) on how to patch up this annoying part of loading images on the web, but I chose to stick with this old faithful method.
 
 <!--more-->
 
-The final piece that's nifty is the `image` lazy loading. I didn't want to load over 20 images as people enter the page, and also didn't want to include a big library, so I went for a quick custom solution. 
+The final nifty bit from this project is the `image` lazy loading. I didn't want to load over 20 images right when people enter the page. I also didn't want to include a big library. So I went for a quick, custom solution.
 
-You can see in the demo below, how the images load once you've scrolled them into the screen. On the site version, I put the margin below the viewport, so you don't see the flash
+You can see in the demo below, how the images load once you've scrolled them into view. On the site version, I put the margin below the viewport, so you don't see the flash.
 
 {{< codepen abOZRMe >}}
 
-This is using the [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) which is now supported by all modern browsers. (Although a fallback can never hurt). And is using `noscript` tags to hold the HTML that I ultimately want to inject.
+This uses the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API), which is now supported by all modern browsers. (Although, a fallback can never hurt.) The `noscript` tags are used to hold the HTML that I ultimately want to inject.
 
 And there we have it, the bits'n'pieces breakdown of Always Judge a Book by its Cover.
 


### PR DESCRIPTION
I just did some minor tweaking to the phrasing of Always Judge a Book by its Cover.

For 8 Bit Code, I changed a sentence slightly so that a piece of inline code wouldn't wrap to a new line. This change was necessary after the max-width of the article changed in c41fbd7f1ac2fe388bbd0204af106eeab4541443. _(In my commit description I credited it to 3a2ccfe2da7e2bc9c45b02a2c0ebe4fb61723819, but that's not technically true.)_