### PR TITLE
broider two-bit -> one-bit

### DIFF
--- a/content/posts/2020-03-02-broider.md
+++ b/content/posts/2020-03-02-broider.md
@@ -8,7 +8,7 @@ tags: [code, art]
 
 The aptly named [*broider*](https://maxbittker.github.io/broider/) by [Max Bittker](https://maxbittker.com/) is a nifty tool for creating, and ornamenting your borders.
 
-Broider allows you to paint your borders in a two-bit style (that's either the bit is on or off, no colors), with a few small assists to help keep things in line: a 9x9 grid, an undo button (for people like me who never get things right the first time) and a little lock button that will keep all of your painting symmetrical.
+Broider allows you to paint your borders in a one-bit style (that's either the bit is on or off, no colors), with a few small assists to help keep things in line: a 9x9 grid, an undo button (for people like me who never get things right the first time) and a little lock button that will keep all of your painting symmetrical.
 
 {{< twitter 1234532026591563776 >}}
 


### PR DESCRIPTION
Sorry to be pedantic! I did have "two-bit" in my readme, but one bit is technically more correct`*`.

Thanks again for the write-up, I linked it from my readme because it explains the project better than I did!


`*` https://en.wikipedia.org/wiki/Color_depth