### PR TITLE
Enable syntax highlighting in blocks of code

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,8 @@ outputs:
 outputFormats:
   rss:
     baseName: feed
+
+markup:
+  highlight:
+    style: monokailight
+    guessSyntax: true

--- a/content/posts/2020-02-15-eight-bit-code.md
+++ b/content/posts/2020-02-15-eight-bit-code.md
@@ -20,7 +20,7 @@ Here, we have [Sierpiński's Triangle](https://en.wikipedia.org/wiki/Sierpi%C5%8
 
 {{< twitter 1226924794077159425 >}}
 
-This is a great instance of a beautiful and beloved [staple](https://10print.org/) in the world of generative code: `10 PRINT CHR$(205.5+RND(1)); : GOTO 10` The randomization of two characters shows so much complexity and beauty!
+This is a great instance of a beautiful and beloved [staple](https://10print.org/) in the world of generative code: {{< highlight basic >}}10 PRINT CHR$(205.5+RND(1)); : GOTO 10{{< / highlight >}} The randomization of two characters shows so much complexity and beauty!
 
 {{< twitter 1228093563143180288 >}}
 

--- a/content/posts/2020-02-26-plink-plonk.md
+++ b/content/posts/2020-02-26-plink-plonk.md
@@ -23,32 +23,32 @@ So how does this work? Lets break it down!
 
 Firstly, the script creates an [Audio Context](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API), which the browser will use to create audio on the fly.
 
-```
+```js {linenos=inline,linenostart=10}
 const audioCtx = new AudioContext()
 ```
 
 Then, it makes a [Mutation Observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)!
 
-```
+```java {linenos=inline,linenostart=11}
 const observer = new MutationObserver(..
 ```
 
 The Mutation Observer will call its callback every time a mutation happens within its applied elements. In this script, you can see those elements defined in the final lines.
 
-```
+```js {linenos=inline,linenostart=25}
 observer.observe(document, {
   attributes: true,
   childList: true,
   subtree: true,
   characterData: true,
-}) 
+})
 ```
 
 Here, it applies to `document` (the whole webpage) and will trigger when any of `attributes`, `childList`, `subTree` & `characterData` properties change... which covers pretty much any change.
 
 The final block of code manages the creation of the audio.
 
-```
+```js {linenos=inline,linenostart=12}
 const oscillator = audioCtx.createOscillator()
 
 oscillator.connect(audioCtx.destination)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -41,15 +41,20 @@ code {
 
 pre {
   line-height: 22px;
-  background: rgba(0, 0, 0, 0.02);
+  background: rgba(0, 0, 0, 0.05) !important;
   border-radius: 3px;
   border: 1px solid #ddd;
   padding: 10px;
+  overflow-x: scroll;
 }
 
 pre code {
   background: none;
   border: none;
+}
+
+.highlight pre code {
+  padding: 0;
 }
 
 header {


### PR DESCRIPTION
I noticed that a couple of the recent posts had blocks of code in them. I checked [Hugo's site](https://gohugo.io/content-management/syntax-highlighting/#readout) and it includes Chroma syntax highlighting by default. So I picked a theme that I thought matched the rest of the site and defined the language of the blocks of code that were included in a couple posts. @tholman let me know if you think a [different theme](https://xyproto.github.io/splash/docs/all.html) would look better.